### PR TITLE
Include dimensions validations to Paperclip proper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .bundle
 tmp
 .DS_Store
+.idea
 
 *.log
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem 'sqlite3', '~> 1.3.8', :platforms => :ruby
 gem 'pry'
+gem 'ffprober', '~> 0.5'
 
 # Hinting at development dependencies
 # Prevents bundler from taking a long-time to resolve

--- a/lib/paperclip/geometry.rb
+++ b/lib/paperclip/geometry.rb
@@ -92,16 +92,16 @@ module Paperclip
     # destination Geometry would be completely filled by the source image, and any
     # overhanging image would be cropped. Useful for square thumbnail images. The cropping
     # is weighted at the center of the Geometry.
-    def transformation_to dst, crop = false
+    def transformation_to(dst, crop = false)
       if crop
-        ratio = Geometry.new( dst.width / self.width, dst.height / self.height )
+        ratio = Geometry.new(dst.width / self.width, dst.height / self.height)
         scale_geometry, scale = scaling(dst, ratio)
         crop_geometry         = cropping(dst, ratio, scale)
       else
         scale_geometry        = dst.to_s
       end
 
-      [ scale_geometry, crop_geometry ]
+      [scale_geometry, crop_geometry]
     end
 
     # resize to a new geometry
@@ -133,19 +133,19 @@ module Paperclip
 
     private
 
-    def scaling dst, ratio
+    def scaling(dst, ratio)
       if ratio.horizontal? || ratio.square?
-        [ "%dx" % dst.width, ratio.width ]
+        ["%dx" % dst.width, ratio.width]
       else
-        [ "x%d" % dst.height, ratio.height ]
+        ["x%d" % dst.height, ratio.height]
       end
     end
 
-    def cropping dst, ratio, scale
+    def cropping(dst, ratio, scale)
       if ratio.horizontal? || ratio.square?
-        "%dx%d+%d+%d" % [ dst.width, dst.height, 0, (self.height * scale - dst.height) / 2 ]
+        "%dx%d+%d+%d" % [dst.width, dst.height, 0, (self.height * scale - dst.height) / 2]
       else
-        "%dx%d+%d+%d" % [ dst.width, dst.height, (self.width * scale - dst.width) / 2, 0 ]
+        "%dx%d+%d+%d" % [dst.width, dst.height, (self.width * scale - dst.width) / 2, 0]
       end
     end
 

--- a/lib/paperclip/validators.rb
+++ b/lib/paperclip/validators.rb
@@ -7,13 +7,14 @@ require 'paperclip/validators/attachment_presence_validator'
 require 'paperclip/validators/attachment_size_validator'
 require 'paperclip/validators/media_type_spoof_detection_validator'
 require 'paperclip/validators/attachment_file_type_ignorance_validator'
+require 'paperclip/validators/attachment_dimensions_validator'
 
 module Paperclip
   module Validators
     extend ActiveSupport::Concern
 
     included do
-      extend  HelperMethods
+      extend HelperMethods
       include HelperMethods
     end
 
@@ -40,8 +41,8 @@ module Paperclip
             validator_kind = $1.underscore.to_sym
 
             if options.has_key?(validator_kind)
-              validator_options = options.delete(validator_kind)
-              validator_options = {} if validator_options == true
+              validator_options   = options.delete(validator_kind)
+              validator_options   = {} if validator_options == true
               conditional_options = options.slice(:if, :unless)
               Array.wrap(validator_options).each do |local_options|
                 method_name = Paperclip::Validators.const_get(constant.to_s).helper_method_name
@@ -53,7 +54,7 @@ module Paperclip
       end
 
       def validate_before_processing(validator_class, options)
-        options = options.dup
+        options    = options.dup
         attributes = options.delete(:attributes)
         attributes.each do |attribute|
           options[:attributes] = [attribute]
@@ -62,7 +63,7 @@ module Paperclip
       end
 
       def create_validating_before_filter(attribute, validator_class, options)
-        if_clause = options.delete(:if)
+        if_clause     = options.delete(:if)
         unless_clause = options.delete(:unless)
         send(:"before_#{attribute}_post_process", :if => if_clause, :unless => unless_clause) do |*args|
           validator_class.new(options.dup).validate(self)

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -1,0 +1,93 @@
+module Paperclip
+  module Validators
+    class AttachmentDimensionsValidator < ActiveModel::EachValidator
+      AVAILABLE_CHECKS    = %i[max_x max_y].freeze
+      VALID_CONTENT_TYPES = %i[image video].freeze
+
+      def initialize(options)
+        super
+      end
+
+      def self.helper_method_name
+        :validates_attachment_dimensions
+      end
+
+      def validate_each(record, attr_name, _value)
+        asset = record.send(:read_attribute_for_validation, attr_name)
+        return if asset.blank?
+
+        file      = asset.queued_for_write[:original]
+        base_type = record.send(:"#{attr_name}_content_type")
+        return if file.blank? || base_type.blank?
+
+        content_type = base_type.split('/').first.to_sym
+        return unless content_type.in?(VALID_CONTENT_TYPES)
+
+        asset_x_dim, asset_y_dim = extract_dimensions(content_type, file)
+
+        # this should allow for procs to determine the max_x or max_y values
+        # so a user can specify for image/gif that they want 1920x1080 as a max
+        # while for image/png it could be nil or something different
+        options.slice(*AVAILABLE_CHECKS).each do |option, option_value|
+          option_value = option_value.call(record) if option_value.is_a?(Proc)
+
+          # validate x value and y value are within x and y range
+          if dimensions_exceeded?(option, option_value, asset_x_dim, asset_y_dim)
+            record.errors.add(attr_name, "#{axis_string(option)} cannot exceed #{option_value}")
+          end
+        end
+      end
+
+      def check_validity!
+        unless AVAILABLE_CHECKS.any? { |argument| options.has_key?(argument) }
+          raise ArgumentError, "You must pass either :max_x, or :max_y to the validator"
+        end
+      end
+
+      private
+
+      def extract_dimensions(content_type, asset)
+        return image_dimensions(asset) if content_type == :image
+        return video_dimensions(asset) if content_type == :video
+        [0, 0]
+      end
+
+      def image_dimensions(asset)
+        return [0, 0] if asset.blank?
+        geo = Paperclip::Geometry.from_file(asset)
+        return [0, 0] if geo.blank?
+        [geo.width.to_i, geo.height.to_i]
+      end
+
+      def video_dimensions(asset)
+        return [0, 0] if asset.blank?
+        geo = Paperclip::VideoGeometry.from_file(asset)
+        return [0, 0] if geo.blank?
+        [geo.width.to_i, geo.height.to_i]
+      end
+
+      def dimensions_exceeded?(dim_key, axis_limit, x_val, y_val)
+        return x_val < axis_limit if dim_key == :max_x
+        return y_val < axis_limit if dim_key == :max_y
+        true
+      end
+
+      def axis_string(dim_key)
+        return 'X-axis' if dim_key == :max_x
+        'Y-axis' if dim_key == :max_y
+      end
+
+      module HelperMethods
+        # Places ActiveModel validations on the dimensions of an image or video.
+        # Options:
+        # * +max_x+: Value that the x dimension of an asset cannot exceed
+        # * +max_y+: Value that the y dimension of an asset cannot exceed
+        def validates_attachment_dimensions(*attr_names)
+          options = _merge_attributes(attr_names)
+          validates_with AttachmentDimensionsValidator, options.dup
+          validate_before_processing AttachmentDimensionsValidator, options.dup
+        end
+      end
+    end
+  end
+end

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -1,3 +1,5 @@
+require 'paperclip/video_geometry'
+
 module Paperclip
   module Validators
     class AttachmentDimensionsValidator < ActiveModel::EachValidator
@@ -14,7 +16,7 @@ module Paperclip
 
       def validate_each(record, attr_name, _value)
         asset = record.send(:read_attribute_for_validation, attr_name)
-        return unless asset.present? && record.errors.blank?
+        return unless asset.present?
 
         file      = asset.queued_for_write[:original]
         base_type = record.send(:"#{attr_name}_content_type")

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -14,7 +14,7 @@ module Paperclip
 
       def validate_each(record, attr_name, _value)
         asset = record.send(:read_attribute_for_validation, attr_name)
-        return if asset.blank?
+        return unless asset.present? && record.errors.blank?
 
         file      = asset.queued_for_write[:original]
         base_type = record.send(:"#{attr_name}_content_type")

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -13,31 +13,22 @@ module Paperclip
       end
 
       def validate_each(record, attr_name, _value)
-        Paperclip.log("Validating dimensions for (#{record}), (#{attr_name}), (#{_value})")
         asset = record.send(:read_attribute_for_validation, attr_name)
         return if asset.blank?
 
-        Paperclip.log("Found asset")
         file      = asset.queued_for_write[:original]
         base_type = record.send(:"#{attr_name}_content_type")
         return if file.blank? || base_type.blank?
 
-        Paperclip.log("File and content type found")
-
         content_type = base_type.split('/').first.to_sym
         return unless content_type.in?(VALID_CONTENT_TYPES)
 
-        Paperclip.log("Valid content type found")
-
         asset_x_dim, asset_y_dim = extract_dimensions(content_type, file)
-
-        Paperclip.log("Extracted dimensions: #{asset_x_dim}x#{asset_y_dim}")
 
         # this should allow for procs to determine the max_x or max_y values
         # so a user can specify for image/gif that they want 1920x1080 as a max
         # while for image/png it could be nil or something different
         options.slice(*AVAILABLE_CHECKS).each do |option, option_value|
-          Paperclip.log("checking option (#{option}) and option value (#{option_value})")
           option_value = option_value.call(record) if option_value.is_a?(Proc)
 
           # validate x value and y value are within x and y range
@@ -56,7 +47,6 @@ module Paperclip
       private
 
       def extract_dimensions(content_type, asset)
-        Paperclip.log("extracting dimensions for type (#{content_type})")
         return image_dimensions(asset) if content_type == :image
         return video_dimensions(asset) if content_type == :video
         [0, 0]
@@ -77,9 +67,8 @@ module Paperclip
       end
 
       def dimensions_exceeded?(dim_key, axis_limit, x_val, y_val)
-        Paperclip.log("checking if dimension key (#{dim_key}; #{dim_key.class}) and axis limit (#{axis_limit}) exceeds x (#{x_val}) or y (#{y_val})")
-        return x_val < axis_limit if dim_key == :max_x
-        return y_val < axis_limit if dim_key == :max_y
+        return x_val >= axis_limit if dim_key == :max_x
+        return y_val >= axis_limit if dim_key == :max_y
         true
       end
 

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -33,6 +33,9 @@ module Paperclip
         options.slice(*AVAILABLE_CHECKS).each do |option, option_value|
           option_value = option_value.call(record) if option_value.is_a?(Proc)
 
+          # this is to optionally specify that there is no limit for an axis
+          next if option_value.blank?
+
           # validate x value and y value are within x and y range
           if dimensions_exceeded?(option, option_value, asset_x_dim, asset_y_dim)
             record.errors.add(attr_name, "#{axis_string(option)} cannot exceed #{option_value}")

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -13,22 +13,31 @@ module Paperclip
       end
 
       def validate_each(record, attr_name, _value)
+        Paperclip.log("Validating dimensions for (#{record}), (#{attr_name}), (#{_value})")
         asset = record.send(:read_attribute_for_validation, attr_name)
         return if asset.blank?
 
+        Paperclip.log("Found asset")
         file      = asset.queued_for_write[:original]
         base_type = record.send(:"#{attr_name}_content_type")
         return if file.blank? || base_type.blank?
 
+        Paperclip.log("File and content type found")
+
         content_type = base_type.split('/').first.to_sym
         return unless content_type.in?(VALID_CONTENT_TYPES)
 
+        Paperclip.log("Valid content type found")
+
         asset_x_dim, asset_y_dim = extract_dimensions(content_type, file)
+
+        Paperclip.log("Extracted dimensions: #{asset_x_dim}x#{asset_y_dim}")
 
         # this should allow for procs to determine the max_x or max_y values
         # so a user can specify for image/gif that they want 1920x1080 as a max
         # while for image/png it could be nil or something different
         options.slice(*AVAILABLE_CHECKS).each do |option, option_value|
+          Paperclip.log("checking option (#{option}) and option value (#{option_value})")
           option_value = option_value.call(record) if option_value.is_a?(Proc)
 
           # validate x value and y value are within x and y range
@@ -47,6 +56,7 @@ module Paperclip
       private
 
       def extract_dimensions(content_type, asset)
+        Paperclip.log("extracting dimensions for type (#{content_type})")
         return image_dimensions(asset) if content_type == :image
         return video_dimensions(asset) if content_type == :video
         [0, 0]
@@ -67,6 +77,7 @@ module Paperclip
       end
 
       def dimensions_exceeded?(dim_key, axis_limit, x_val, y_val)
+        Paperclip.log("checking if dimension key (#{dim_key}; #{dim_key.class}) and axis limit (#{axis_limit}) exceeds x (#{x_val}) or y (#{y_val})")
         return x_val < axis_limit if dim_key == :max_x
         return y_val < axis_limit if dim_key == :max_y
         true

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -76,17 +76,17 @@ module Paperclip
         return 'X-axis' if dim_key == :max_x
         'Y-axis' if dim_key == :max_y
       end
+    end
 
-      module HelperMethods
-        # Places ActiveModel validations on the dimensions of an image or video.
-        # Options:
-        # * +max_x+: Value that the x dimension of an asset cannot exceed
-        # * +max_y+: Value that the y dimension of an asset cannot exceed
-        def validates_attachment_dimensions(*attr_names)
-          options = _merge_attributes(attr_names)
-          validates_with AttachmentDimensionsValidator, options.dup
-          validate_before_processing AttachmentDimensionsValidator, options.dup
-        end
+    module HelperMethods
+      # Places ActiveModel validations on the dimensions of an image or video.
+      # Options:
+      # * +max_x+: Value that the x dimension of an asset cannot exceed
+      # * +max_y+: Value that the y dimension of an asset cannot exceed
+      def validates_attachment_dimensions(*attr_names)
+        options = _merge_attributes(attr_names)
+        validates_with AttachmentDimensionsValidator, options.dup
+        validate_before_processing AttachmentDimensionsValidator, options.dup
       end
     end
   end

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -72,8 +72,8 @@ module Paperclip
       end
 
       def dimensions_exceeded?(dim_key, axis_limit, x_val, y_val)
-        return x_val >= axis_limit if dim_key == :max_x
-        return y_val >= axis_limit if dim_key == :max_y
+        return x_val > axis_limit if dim_key == :max_x
+        return y_val > axis_limit if dim_key == :max_y
         true
       end
 

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -63,7 +63,7 @@ module Paperclip
 
       def video_dimensions(asset)
         return [0, 0] if asset.blank?
-        geo = Paperclip::VideoGeometry.from_file(asset)
+        geo = Paperclip::VideoGeometry.from_file(asset.path)
         return [0, 0] if geo.blank?
         [geo.width.to_i, geo.height.to_i]
       end

--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -14,7 +14,7 @@ module Paperclip
         :validates_attachment_size
       end
 
-      def validate_each(record, attr_name, value)
+      def validate_each(record, attr_name, _value)
         base_attr_name = attr_name
         attr_name = "#{attr_name}_file_size".to_sym
         value = record.send(:read_attribute_for_validation, attr_name)

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,5 +1,5 @@
 module Paperclip
   unless defined?(Paperclip::VERSION)
-    VERSION = "5.2.1".freeze
+    VERSION = "5.2.2".freeze
   end
 end

--- a/lib/paperclip/video_geometry.rb
+++ b/lib/paperclip/video_geometry.rb
@@ -1,0 +1,17 @@
+require 'ffprober'
+
+module Paperclip
+
+  # Defines the geometry of a video
+  class VideoGeometry
+    class << self
+      def from_file(file)
+        probe = Ffprober::Parser.from_file(file)
+        return nil if probe.blank?
+        video_stream = probe.video_streams.try(:first)
+        return nil if video_stream.blank?
+        video_stream
+      end
+    end
+  end
+end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -2,19 +2,19 @@ $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 require 'paperclip/version'
 
 Gem::Specification.new do |s|
-  s.name              = "paperclip"
-  s.version           = Paperclip::VERSION
-  s.platform          = Gem::Platform::RUBY
-  s.author            = "Jon Yurek"
-  s.email             = ["jyurek@thoughtbot.com"]
-  s.homepage          = "https://github.com/thoughtbot/paperclip"
-  s.summary           = "File attachments as attributes for ActiveRecord"
-  s.description       = "Easy upload management for ActiveRecord"
-  s.license           = "MIT"
+  s.name        = "paperclip"
+  s.version     = Paperclip::VERSION
+  s.platform    = Gem::Platform::RUBY
+  s.author      = "Jon Yurek"
+  s.email       = ["jyurek@thoughtbot.com"]
+  s.homepage    = "https://github.com/thoughtbot/paperclip"
+  s.summary     = "File attachments as attributes for ActiveRecord"
+  s.description = "Easy upload management for ActiveRecord"
+  s.license     = "MIT"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   if File.exist?('UPGRADING')
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('cocaine', '~> 0.5.5')
   s.add_dependency('mime-types')
   s.add_dependency('mimemagic', '~> 0.3.0')
+  s.add_dependency('ffprober', '~> 0.5')
 
   s.add_development_dependency('activerecord', '>= 4.2.0')
   s.add_development_dependency('shoulda')

--- a/spec/paperclip/validators/attachment_dimensions_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_dimensions_validator_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Paperclip::Validators::AttachmentDimensionsValidator do
+
+end

--- a/spec/paperclip/video_geometry_spec.rb
+++ b/spec/paperclip/video_geometry_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Paperclip::VideoGeometry do
+
+end


### PR DESCRIPTION
Includes:
- Gem-level support for image and video dimension validation
- Dynamic limit setting available
- Adding in ffprobe to gemspec of paperclip for video dimension checking
- PR is Proxima-internal only