### PR TITLE
Adding in ability for Paperclip to validate attached video duration

### DIFF
--- a/lib/paperclip/validators.rb
+++ b/lib/paperclip/validators.rb
@@ -8,6 +8,7 @@ require 'paperclip/validators/attachment_size_validator'
 require 'paperclip/validators/media_type_spoof_detection_validator'
 require 'paperclip/validators/attachment_file_type_ignorance_validator'
 require 'paperclip/validators/attachment_dimensions_validator'
+require 'paperclip/validators/attachment_video_length_validator'
 
 module Paperclip
   module Validators

--- a/lib/paperclip/validators/attachment_dimensions_validator.rb
+++ b/lib/paperclip/validators/attachment_dimensions_validator.rb
@@ -66,7 +66,7 @@ module Paperclip
 
       def video_dimensions(asset)
         return [0, 0] if asset.blank?
-        geo = Paperclip::VideoGeometry.from_file(asset.path)
+        geo = Paperclip::VideoGeometry.from_file_path(asset.path)
         return [0, 0] if geo.blank?
         [geo.width.to_i, geo.height.to_i]
       end

--- a/lib/paperclip/validators/attachment_video_length_validator.rb
+++ b/lib/paperclip/validators/attachment_video_length_validator.rb
@@ -78,8 +78,8 @@ module Paperclip
       # * +max_length+: Value that the y dimension of an asset cannot exceed
       def validates_video_length(*attr_names)
         options = _merge_attributes(attr_names)
-        validates_with AttachmentDimensionsValidator, options.dup
-        validate_before_processing AttachmentDimensionsValidator, options.dup
+        validates_with AttachmentVideoLengthValidator, options.dup
+        validate_before_processing AttachmentVideoLengthValidator, options.dup
       end
     end
   end

--- a/lib/paperclip/validators/attachment_video_length_validator.rb
+++ b/lib/paperclip/validators/attachment_video_length_validator.rb
@@ -59,10 +59,10 @@ module Paperclip
         return true if length_in_seconds.blank?
 
         # return true if the length of a video is lower than the min_length value
-        return length_in_seconds <= limit if option == :min_length
+        return length_in_seconds < limit if option == :min_length
 
         # return true if the length of a video is higher than the max_length value
-        length_in_seconds >= limit if option == :max_length
+        length_in_seconds > limit if option == :max_length
       end
 
       def option_string(option)

--- a/lib/paperclip/validators/attachment_video_length_validator.rb
+++ b/lib/paperclip/validators/attachment_video_length_validator.rb
@@ -25,7 +25,7 @@ module Paperclip
         content_type = base_type.split('/').first.to_sym
         return unless content_type.in?(VALID_CONTENT_TYPES)
 
-        length_in_seconds = Paperclip::VideoDuration.from_file_path(asset.path)
+        length_in_seconds = Paperclip::VideoDuration.from_file_path(file.path)
 
         # this should allow for procs to determine the max_x or max_y values
         # so a user can specify for image/gif that they want 1920x1080 as a max

--- a/lib/paperclip/validators/attachment_video_length_validator.rb
+++ b/lib/paperclip/validators/attachment_video_length_validator.rb
@@ -59,10 +59,10 @@ module Paperclip
         return true if length_in_seconds.blank?
 
         # return true if the length of a video is lower than the min_length value
-        return limit < length_in_seconds if option == :min_length
+        return limit <= length_in_seconds if option == :min_length
 
         # return true if the length of a video is higher than the max_length value
-        limit > length_in_seconds if option == :max_length
+        limit >= length_in_seconds if option == :max_length
       end
 
       def option_string(option)

--- a/lib/paperclip/validators/attachment_video_length_validator.rb
+++ b/lib/paperclip/validators/attachment_video_length_validator.rb
@@ -59,10 +59,10 @@ module Paperclip
         return true if length_in_seconds.blank?
 
         # return true if the length of a video is lower than the min_length value
-        return limit <= length_in_seconds if option == :min_length
+        return length_in_seconds <= limit if option == :min_length
 
         # return true if the length of a video is higher than the max_length value
-        limit >= length_in_seconds if option == :max_length
+        length_in_seconds >= limit if option == :max_length
       end
 
       def option_string(option)

--- a/lib/paperclip/validators/attachment_video_length_validator.rb
+++ b/lib/paperclip/validators/attachment_video_length_validator.rb
@@ -1,0 +1,86 @@
+require 'paperclip/video_duration'
+
+module Paperclip
+  module Validators
+    class AttachmentVideoLengthValidator < ActiveModel::EachValidator
+      AVAILABLE_CHECKS    = %i[min_length max_length].freeze
+      VALID_CONTENT_TYPES = %i[video].freeze
+
+      def initialize(options)
+        super
+      end
+
+      def self.helper_method_name
+        :validates_video_length
+      end
+
+      def validate_each(record, attr_name, _value)
+        asset = record.send(:read_attribute_for_validation, attr_name)
+        return unless asset.present?
+
+        file      = asset.queued_for_write[:original]
+        base_type = record.send(:"#{attr_name}_content_type")
+        return if file.blank? || base_type.blank?
+
+        content_type = base_type.split('/').first.to_sym
+        return unless content_type.in?(VALID_CONTENT_TYPES)
+
+        length_in_seconds = Paperclip::VideoDuration.from_file_path(asset.path)
+
+        # this should allow for procs to determine the max_x or max_y values
+        # so a user can specify for image/gif that they want 1920x1080 as a max
+        # while for image/png it could be nil or something different
+        options.slice(*AVAILABLE_CHECKS).each do |option, option_value|
+          option_value = option_value.call(record) if option_value.is_a?(Proc)
+
+          # this is to optionally specify that there is no limit for an axis
+          next if option_value.blank?
+
+          # validate x value and y value are within x and y range
+          if limits_exceeded?(option, option_value, length_in_seconds)
+            record.errors.add(attr_name, "Asset cannot exceed #{option_string(option)} of #{option_value}")
+          end
+        end
+      end
+
+      def check_validity!
+        unless AVAILABLE_CHECKS.any? { |argument| options.has_key?(argument) }
+          raise ArgumentError, "You must pass either :min_length, or :max_length to the validator"
+        end
+      end
+
+      private
+
+      def limits_exceeded?(option, limit, length_in_seconds)
+        # don't enforce blank limits
+        return false if limit.blank?
+
+        # automatically fail blank lengths
+        return true if length_in_seconds.blank?
+
+        # return true if the length of a video is lower than the min_length value
+        return limit < length_in_seconds if option == :min_length
+
+        # return true if the length of a video is higher than the max_length value
+        limit > length_in_seconds if option == :max_length
+      end
+
+      def option_string(option)
+        return 'minimum length' if option == :min_length
+        'maximum length' if option == :max_length
+      end
+    end
+
+    module HelperMethods
+      # Places ActiveModel validations on the length of a video.
+      # Options:
+      # * +min_length+: Minimum Length allowed of a video in seconds
+      # * +max_length+: Value that the y dimension of an asset cannot exceed
+      def validates_video_length(*attr_names)
+        options = _merge_attributes(attr_names)
+        validates_with AttachmentDimensionsValidator, options.dup
+        validate_before_processing AttachmentDimensionsValidator, options.dup
+      end
+    end
+  end
+end

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,5 +1,5 @@
 module Paperclip
   unless defined?(Paperclip::VERSION)
-    VERSION = "5.2.2".freeze
+    VERSION = "5.2.3".freeze
   end
 end

--- a/lib/paperclip/video_duration.rb
+++ b/lib/paperclip/video_duration.rb
@@ -1,16 +1,15 @@
 require 'ffprober'
 
 module Paperclip
-
-  # Defines the geometry of a video
-  class VideoGeometry
+  # Get duration of a video
+  class VideoDuration
     class << self
-      def from_file_path(file)
-        probe = Ffprober::Parser.from_file(file)
+      def from_file_path(path)
+        probe = Ffprober::Parser.from_file(path)
         return nil if probe.blank?
         video_stream = probe.video_streams.try(:first)
         return nil if video_stream.blank?
-        video_stream
+        video_stream.try(:duration).try(:to_f)
       end
     end
   end

--- a/spec/paperclip/validators/attachment_video_length_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_video_length_validator_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Paperclip::Validators::AttachmentVideoLengthValidator do
+
+end

--- a/spec/paperclip/video_duration_spec.rb
+++ b/spec/paperclip/video_duration_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Paperclip::VideoDuration do
+
+end


### PR DESCRIPTION
New functionality will:
* Get metadata for video file with Ffprobe
* Use this metadata to return the duration of the video as a float OR as a nil value if not present
* Based on whether a programmer provides `min_length` or `max_length`, these will be validated. At least one but not both need to be provided
* Durations are assessed by seconds
* If a duration is less than the minimum, it will be invalid. It *can* be equal
* If a duration is greater than the max, it will be invalid. It *can* be equal
